### PR TITLE
 The "openzfs-run-ztest" Jenkins job fails

### DIFF
--- a/ansible/roles/openzfs-jenkins-slave/files/usr/local/run-ztest.sh
+++ b/ansible/roles/openzfs-jenkins-slave/files/usr/local/run-ztest.sh
@@ -4,7 +4,6 @@
 #
 
 set -o nounset
-set -o errexit
 
 source "${CI_SH_LIB}/common.sh"
 


### PR DESCRIPTION
Changed run-ztest.sh to exclude `set -o errexit`, which allows the test
to complete and not exit during the first error.
