### PR TITLE
Add fio to list of packages to install

### DIFF
--- a/ansible/roles/initialize-omnios/tasks/main.yml
+++ b/ansible/roles/initialize-omnios/tasks/main.yml
@@ -3,6 +3,7 @@
   pkg5:
     name:
       - pkg:/developer/astdev
+      - pkg:/benchmark/fio
       - pkg:/developer/build/make
       - pkg:/developer/build/onbld
       - pkg:/developer/gcc44


### PR DESCRIPTION
The benchmark utility fio is required by the new compressed send/recv
tests, so we should add it to the omnios image.
